### PR TITLE
Add Alacritty colors

### DIFF
--- a/appsignal-dark-alacritty.yml
+++ b/appsignal-dark-alacritty.yml
@@ -5,7 +5,7 @@ colors:
     foreground: '0xb1bfc6'
   normal:
     black: '0x313f46'
-    red: '0xc31633'
+    red: '0xff5673'
     green: '0x4caf50'
     yellow: '0xefaa04'
     blue: '0x0961c4'
@@ -14,7 +14,7 @@ colors:
     white: '0xb1bfc6'
   bright:
     black: '0x4b5960'
-    red: '0xff5673'
+    red: '0xc31633'
     green: '0x8cef90'
     yellow: '0xffea44'
     blue: '0x49a1ff'

--- a/appsignal-dark-alacritty.yml
+++ b/appsignal-dark-alacritty.yml
@@ -1,0 +1,23 @@
+# Colors (AppSignal Dark)
+colors:
+  primary:
+    background: '0x313f46'
+    foreground: '0xb1bfc6'
+  normal:
+    black: '0x313f46'
+    red: '0xc31633'
+    green: '0x4caf50'
+    yellow: '0xefaa04'
+    blue: '0x0961c4'
+    magenta: '0x8a0c8f'
+    cyan: '0x067d8a'
+    white: '0xb1bfc6'
+  bright:
+    black: '0x4b5960'
+    red: '0xff5673'
+    green: '0x8cef90'
+    yellow: '0xffea44'
+    blue: '0x49a1ff'
+    magenta: '0xca4ccf'
+    cyan: '0x46bdca'
+    white: '0xf2fbff'

--- a/appsignal-light-alacritty.yml
+++ b/appsignal-light-alacritty.yml
@@ -1,0 +1,23 @@
+# Colors (AppSignal Light)
+colors:
+  primary:
+    background: '0xf2fbff'
+    foreground: '0x313f46'
+  normal:
+    black: '0x313f46'
+    red: '0xc31633'
+    green: '0x4caf4f'
+    yellow: '0xefaa03'
+    blue: '0x0961c4'
+    magenta: '0x8a0c8f'
+    cyan: '0x067c8a'
+    white: '0xb1bfc6'
+  bright:
+    black: '0x4b5960'
+    red: '0xff5673'
+    green: '0x8bef90'
+    yellow: '0xffe943'
+    blue: '0x49a1ff'
+    magenta: '0xca4ccf'
+    cyan: '0x46bcca'
+    white: '0xf2fbff'


### PR DESCRIPTION
# #3 Add .yml color schemes for [Alacritty](https://github.com/alacritty/alacritty)

<img width="870" alt="Screen Shot 2020-02-21 at 13 22 24" src="https://user-images.githubusercontent.com/13198813/75030680-4f04a000-54ad-11ea-97dc-2c3300141b41.png">

<img width="870" alt="Screen Shot 2020-02-21 at 13 20 20" src="https://user-images.githubusercontent.com/13198813/75030646-3a280c80-54ad-11ea-936d-23146a7aa6c0.png">
